### PR TITLE
Use solc 0.8.26 for RollupUserLogic to avoid the size issue

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -26,7 +26,7 @@ const solidity = {
   ],
   overrides: {
     'src/rollup/RollupUserLogic.sol': {
-      version: '0.8.9',
+      version: '0.8.26',
       settings: {
         optimizer: {
           enabled: true,


### PR DESCRIPTION
### This PR:
Use solc `0.8.26` to compile the `RollupUserLogic`. This compiler can compile this contract into a smaller size and make it deployable on L1.
