### PR TITLE
remove global state

### DIFF
--- a/src/state/Deserialize.sol
+++ b/src/state/Deserialize.sol
@@ -259,7 +259,7 @@ library Deserialize {
 
         // using constant ints for array size requires newer solidity
         bytes32[2] memory bytes32Vals;
-        uint64[3] memory u64Vals;
+        uint64[2] memory u64Vals;
 
         for (uint8 i = 0; i < GlobalStateLib.BYTES32_VALS_NUM; i++) {
             (bytes32Vals[i], offset) = b32(proof, offset);

--- a/src/state/GlobalState.sol
+++ b/src/state/GlobalState.sol
@@ -6,12 +6,12 @@ pragma solidity ^0.8.0;
 
 struct GlobalState {
     bytes32[2] bytes32Vals;
-    uint64[3] u64Vals;
+    uint64[2] u64Vals;
 }
 
 library GlobalStateLib {
     uint16 internal constant BYTES32_VALS_NUM = 2;
-    uint16 internal constant U64_VALS_NUM = 3;
+    uint16 internal constant U64_VALS_NUM = 2;
 
     function hash(GlobalState memory state) internal pure returns (bytes32) {
         return
@@ -22,7 +22,6 @@ library GlobalStateLib {
                     state.bytes32Vals[1],
                     state.u64Vals[0],
                     state.u64Vals[1],
-                    state.u64Vals[2]
                 )
             );
     }
@@ -47,7 +46,6 @@ library GlobalStateLib {
         return (state.bytes32Vals[0] == bytes32(0) &&
             state.bytes32Vals[1] == bytes32(0) &&
             state.u64Vals[0] == 0 &&
-            state.u64Vals[1] == 0 &&
-            state.u64Vals[2] == 0);
+            state.u64Vals[1] == 0);
     }
 }

--- a/src/state/GlobalState.sol
+++ b/src/state/GlobalState.sol
@@ -21,7 +21,7 @@ library GlobalStateLib {
                     state.bytes32Vals[0],
                     state.bytes32Vals[1],
                     state.u64Vals[0],
-                    state.u64Vals[1],
+                    state.u64Vals[1]
                 )
             );
     }


### PR DESCRIPTION
Remove the extra global state that we added for the continuity check of hotshot blocks

https://github.com/EspressoSystems/nitro-espresso-integration/pull/210