### PR TITLE
Disable failing CI jobs

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: forge test
   tests:
     name: Contract tests
-    runs-on: ubuntu-8
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
@@ -148,6 +148,7 @@ jobs:
       - name: Test 4844
         run: yarn test:4844
   test-e2e:
+    if: false # broken
     name: Test e2e
     runs-on: ubuntu-latest
     steps:
@@ -178,6 +179,7 @@ jobs:
       - name: Run e2e tests
         run: yarn test:e2e
   test-e2e-custom-fee-token:
+    if: false # broken
     name: Test e2e custom fee token
     runs-on: ubuntu-latest
     steps:
@@ -209,6 +211,7 @@ jobs:
       - name: Run e2e tests
         run: yarn test:e2e
   test-e2e-fee-token-6-decimals:
+    if: false # broken
     name: Test e2e fee token with 6 decimals
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Build
         run: forge test
   tests:
+    if: false # broken
     name: Contract tests
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
These jobs don't work at the moment. It's less confusing and spammy if we disable it.