### PR TITLE
Add names to the deprecated functions to not break abi

### DIFF
--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -47,7 +47,7 @@ import {IGasRefunder} from "../libraries/IGasRefunder.sol";
 import {GasRefundEnabled} from "../libraries/GasRefundEnabled.sol";
 import "../libraries/ArbitrumChecker.sol";
 import {IERC20Bridge} from "./IERC20Bridge.sol";
-import {IEspressoTEEVerifier} from "../bridge/IEspressoTEEVerifier.sol";
+import {EspressoTEEVerifier} from "../bridge/EspressoTEEVerifier.sol";
 
 /**
  * @title  Accepts batches from the sequencer and adds them to the rollup inbox.
@@ -132,7 +132,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     // True if the chain this SequencerInbox is deployed on uses custom fee token
     bool public immutable isUsingFeeToken;
 
-    IEspressoTEEVerifier public espressoTEEVerifier;
+    EspressoTEEVerifier public espressoTEEVerifier;
 
     constructor(uint256 _maxDataSize, IReader4844 reader4844_, bool _isUsingFeeToken) {
         maxDataSize = _maxDataSize;
@@ -185,7 +185,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         Deprecated because we created another `initialize` function that accepts the `EspressoTEEVerifier` contract
         address as a parameter which is used by the `SequencerInbox` contract to verify the TEE attestation quote.
      */
-    function initialize(IBridge, ISequencerInbox.MaxTimeVariation calldata) external onlyDelegated {
+    function initialize(IBridge bridge_, ISequencerInbox.MaxTimeVariation calldata maxTimeVariation_) external onlyDelegated {
         revert Deprecated();
     }
 
@@ -213,7 +213,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         rollup = bridge_.rollup();
 
         _setMaxTimeVariation(maxTimeVariation_);
-        espressoTEEVerifier = IEspressoTEEVerifier(_espressoTEEVerifier);
+        espressoTEEVerifier = EspressoTEEVerifier(_espressoTEEVerifier);
     }
 
     /// @notice Allows the rollup owner to sync the rollup address
@@ -341,10 +341,10 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
 
     /// @dev Deprecated, kept for abi generation and will be removed in the future
     function addSequencerL2BatchFromOrigin(
-        uint256,
-        bytes calldata,
-        uint256,
-        IGasRefunder
+        uint256 sequencerNumber,
+        bytes calldata data,
+        uint256 afterDelayedMessagesRead,
+        IGasRefunder gasRefunder
     ) external pure {
         revert Deprecated();
     }
@@ -856,7 +856,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     }
 
     function setEspressoTEEVerifier(address _espressoTEEVerifier) external onlyRollupOwner {
-        espressoTEEVerifier = IEspressoTEEVerifier(_espressoTEEVerifier);
+        espressoTEEVerifier = EspressoTEEVerifier(_espressoTEEVerifier);
         emit OwnerFunctionCalled(6);
     }
 

--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -47,7 +47,7 @@ import {IGasRefunder} from "../libraries/IGasRefunder.sol";
 import {GasRefundEnabled} from "../libraries/GasRefundEnabled.sol";
 import "../libraries/ArbitrumChecker.sol";
 import {IERC20Bridge} from "./IERC20Bridge.sol";
-import {EspressoTEEVerifier} from "../bridge/EspressoTEEVerifier.sol";
+import {IEspressoTEEVerifier} from "../bridge/IEspressoTEEVerifier.sol";
 
 /**
  * @title  Accepts batches from the sequencer and adds them to the rollup inbox.
@@ -132,7 +132,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     // True if the chain this SequencerInbox is deployed on uses custom fee token
     bool public immutable isUsingFeeToken;
 
-    EspressoTEEVerifier public espressoTEEVerifier;
+    IEspressoTEEVerifier public espressoTEEVerifier;
 
     constructor(uint256 _maxDataSize, IReader4844 reader4844_, bool _isUsingFeeToken) {
         maxDataSize = _maxDataSize;
@@ -185,7 +185,10 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         Deprecated because we created another `initialize` function that accepts the `EspressoTEEVerifier` contract
         address as a parameter which is used by the `SequencerInbox` contract to verify the TEE attestation quote.
      */
-    function initialize(IBridge bridge_, ISequencerInbox.MaxTimeVariation calldata maxTimeVariation_) external onlyDelegated {
+    function initialize(
+        IBridge bridge_,
+        ISequencerInbox.MaxTimeVariation calldata maxTimeVariation_
+    ) external onlyDelegated {
         revert Deprecated();
     }
 
@@ -213,7 +216,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         rollup = bridge_.rollup();
 
         _setMaxTimeVariation(maxTimeVariation_);
-        espressoTEEVerifier = EspressoTEEVerifier(_espressoTEEVerifier);
+        espressoTEEVerifier = IEspressoTEEVerifier(_espressoTEEVerifier);
     }
 
     /// @notice Allows the rollup owner to sync the rollup address
@@ -856,7 +859,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     }
 
     function setEspressoTEEVerifier(address _espressoTEEVerifier) external onlyRollupOwner {
-        espressoTEEVerifier = EspressoTEEVerifier(_espressoTEEVerifier);
+        espressoTEEVerifier = IEspressoTEEVerifier(_espressoTEEVerifier);
         emit OwnerFunctionCalled(6);
     }
 

--- a/src/rollup/BridgeCreator.sol
+++ b/src/rollup/BridgeCreator.sol
@@ -86,10 +86,10 @@ contract BridgeCreator is Ownable {
      * been posted by a batch poster running in the TEE.
      */
     function createBridge(
-        address,
-        address,
-        address,
-        ISequencerInbox.MaxTimeVariation calldata
+        address adminProxy,
+        address rollup,
+        address nativeToken,
+        ISequencerInbox.MaxTimeVariation calldata maxTimeVariation
     ) external returns (BridgeContracts memory) {
         revert Deprecated();
     }


### PR DESCRIPTION
Adding back variable names to deprecated functions because it otherwise breaks the abi