### PR TITLE
Fix rollup creator

### DIFF
--- a/scripts/deploymentUtils.ts
+++ b/scripts/deploymentUtils.ts
@@ -114,7 +114,7 @@ export async function deployUpgradeExecutor(signer: any): Promise<Contract> {
 }
 
 // Function to handle all deployments of core contracts using deployContract function
-export async function depgoyAllContracts(
+export async function deployAllContracts(
   signer: any,
   maxDataSize: BigNumber,
   verify: boolean = true,

--- a/scripts/deploymentUtils.ts
+++ b/scripts/deploymentUtils.ts
@@ -114,11 +114,10 @@ export async function deployUpgradeExecutor(signer: any): Promise<Contract> {
 }
 
 // Function to handle all deployments of core contracts using deployContract function
-export async function deployAllContracts(
+export async function depgoyAllContracts(
   signer: any,
   maxDataSize: BigNumber,
   verify: boolean = true,
-  espressoLightClientAddr?: string
 ): Promise<Record<string, Contract>> {
   const isOnArb = await _isRunningOnArbitrum(signer)
 
@@ -198,11 +197,10 @@ export async function deployAllContracts(
     [],
     verify
   )
-  const hostIoArg = espressoLightClientAddr ? [espressoLightClientAddr] : []
   const proverHostIo = await deployContract(
     'OneStepProverHostIo',
     signer,
-    hostIoArg,
+    [],
     verify
   )
 

--- a/scripts/local-deployment/deployCreatorAndCreateRollup.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateRollup.ts
@@ -26,10 +26,6 @@ async function main() {
     throw new Error('PARENT_CHAIN_ID not set')
   }
 
-  let espressoLightClientAddr = process.env.LIGHT_CLIENT_ADDR as string
-  if (!espressoLightClientAddr) {
-    throw new Error("LIGHT_CLIENT_ADDR not set")
-  }
 
   const deployerWallet = new ethers.Wallet(
     deployerPrivKey,
@@ -49,7 +45,7 @@ async function main() {
 
   /// deploy templates and rollup creator
   console.log('Deploy RollupCreator')
-  const contracts = await deployAllContracts(deployerWallet, maxDataSize, false, espressoLightClientAddr)
+  const contracts = await deployAllContracts(deployerWallet, maxDataSize, false)
 
   //  for local deployment, we use a mock address
   const espressoTEEVerifierMock = await deployContract(


### PR DESCRIPTION
Closes #[382](https://github.com/EspressoSystems/nitro-espresso-integration/issues/382)

### This PR:
Fixes the scripts relied upon by the rollup creator to allow it to properly deploy the OSP contracts

### This PR does not:
fix the test-node. This must occur in a separate PR in that repo

### Key places to review:
deploymentUtils.ts and deployCreatorAndCreateRollup.ts