### PR TITLE
Disable delay buffer in dev rollup

### DIFF
--- a/scripts/rollupCreation.ts
+++ b/scripts/rollupCreation.ts
@@ -339,7 +339,7 @@ async function _getDevRollupConfig(
     layerZeroSmallStepEdgeHeight: 2 ** 23,
     numBigStepLevel: 1,
     challengeGracePeriodBlocks: 10,
-    bufferConfig: { threshold: 600, max: 14400, replenishRateInBasis: 500 },
+    bufferConfig: { threshold: 0 , max: 14400, replenishRateInBasis: 500 },
     sequencerInboxMaxTimeVariation: {
       delayBlocks: ethers.BigNumber.from('5760'),
       futureBlocks: ethers.BigNumber.from('12'),


### PR DESCRIPTION
Currently, Espresso integration doesn't support delay buffer. However, in the dev rollup config, it is enabled by default. Dev node config is used in the `nitro-testnode` repo. This PR modifies it and it should not make any difference to any other things.
