### PR TITLE
adds etherscan v2 support ‖ min version for migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@arbitrum/sdk": "^3.7.3",
     "@ethersproject/providers": "^5.8.0",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",
-    "@nomicfoundation/hardhat-verify": "^2.0.13",
+    "@nomicfoundation/hardhat-verify": "^2.0.14",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
     "@typechain/ethers-v5": "^10.2.1",
     "@typechain/hardhat": "^6.1.6",


### PR DESCRIPTION
### This PR:
<!-- bumps @nomicfoundation/hardhat-verify to ^2.0.14 for etherscan v2 support -->

### Key places to review:
<!-- package.json (dep update) -->