### PR TITLE
feat(ci): add mutation testing with dregs

### DIFF
--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -45,6 +45,16 @@ jobs:
           version: stable
           cache: false
 
+      - name: Setup node/yarn
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+          cache-dependency-path: '**/yarn.lock'
+
+      - name: Install packages
+        run: yarn
+
       - name: Configure shard count
         id: shards
         run: |

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -1,0 +1,175 @@
+name: Mutation Test
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    paths:
+      - "src/**"
+      - "test/**"
+      - "dregs.toml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      has_mutants: ${{ steps.check.outputs.has_mutants }}
+      total_shards: ${{ steps.shards.outputs.total_shards }}
+      shard_matrix: ${{ steps.shards.outputs.shard_matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          filter: blob:none
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: dregs
+
+      - uses: EspressoSystems/dregs/.github/actions/install-solc@main
+        with:
+          version: "0.8.30"
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+          cache: false
+
+      - name: Configure shard count
+        id: shards
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            total_shards=3
+          else
+            total_shards=10
+          fi
+          echo "total_shards=${total_shards}" >> "$GITHUB_OUTPUT"
+
+          shard_matrix=$(seq 1 "${total_shards}" | jq -sc '.')
+          echo "shard_matrix=${shard_matrix}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate mutants
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            dregs generate --project . --diff-base "origin/${{ github.base_ref }}" --output ./mutants
+          else
+            dregs generate --project . --output ./mutants
+          fi
+
+      - name: Check for mutants
+        id: check
+        run: |
+          if [[ -f mutants/manifest.json ]] && \
+             [[ "$(jq '.mutants | length' mutants/manifest.json)" -gt 0 ]]; then
+            echo "has_mutants=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_mutants=false" >> "$GITHUB_OUTPUT"
+            echo "No mutants generated, skipping test shards." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload mutants
+        if: steps.check.outputs.has_mutants == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutants
+          path: mutants/
+          if-no-files-found: error
+
+  test-shard:
+    needs: [generate]
+    if: needs.generate.outputs.has_mutants == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJson(needs.generate.outputs.shard_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: dregs
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+          cache: false
+
+      - name: Setup node/yarn
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+          cache-dependency-path: '**/yarn.lock'
+
+      - name: Install packages
+        run: yarn
+
+      - name: Download mutants
+        uses: actions/download-artifact@v8
+        with:
+          name: mutants
+          path: mutants/
+
+      - name: Run mutation tests (shard ${{ matrix.shard }}/${{ needs.generate.outputs.total_shards }})
+        run: |
+          dregs test \
+            --manifest ./mutants/manifest.json \
+            --project . \
+            --partition "slice:${{ matrix.shard }}/${{ needs.generate.outputs.total_shards }}" \
+            --output "results-${{ matrix.shard }}.json"
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: results-${{ matrix.shard }}
+          path: results-${{ matrix.shard }}.json
+          if-no-files-found: error
+
+  report:
+    needs: [generate, test-shard]
+    if: "!cancelled() && needs.generate.outputs.has_mutants == 'true'"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: dregs
+
+      - name: Download mutants
+        uses: actions/download-artifact@v8
+        with:
+          name: mutants
+          path: mutants/
+
+      - name: Download all results
+        uses: actions/download-artifact@v8
+        with:
+          pattern: results-*
+          path: results/
+
+      - name: Generate report
+        run: |
+          dregs report ./mutants/manifest.json results/results-*/results-*.json \
+            --format markdown | tee "$GITHUB_STEP_SUMMARY" > mutation-report.md
+
+      - name: Upload report
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutation-report
+          path: mutation-report.md
+          if-no-files-found: error

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -30,14 +30,10 @@ jobs:
           fetch-depth: 0
           filter: blob:none
 
+      - uses: taiki-e/install-action@cargo-binstall
+
       - name: Install dregs
-        run: |
-          curl -fSL https://api.github.com/repos/EspressoSystems/dregs/releases \
-            | jq -r '[.[] | .assets[] | select(.name == "dregs-x86_64-unknown-linux-musl.tar.gz")][0].url' \
-            | xargs curl -fL -H "Accept: application/octet-stream" -o dregs.tar.gz
-          tar xzf dregs.tar.gz
-          sudo mv dregs /usr/local/bin/dregs
-          dregs --version
+        run: cargo binstall --git https://github.com/EspressoSystems/dregs dregs --no-confirm
 
       - uses: EspressoSystems/dregs/.github/actions/install-solc@main
         with:
@@ -103,14 +99,10 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: taiki-e/install-action@cargo-binstall
+
       - name: Install dregs
-        run: |
-          curl -fSL https://api.github.com/repos/EspressoSystems/dregs/releases \
-            | jq -r '[.[] | .assets[] | select(.name == "dregs-x86_64-unknown-linux-musl.tar.gz")][0].url' \
-            | xargs curl -fL -H "Accept: application/octet-stream" -o dregs.tar.gz
-          tar xzf dregs.tar.gz
-          sudo mv dregs /usr/local/bin/dregs
-          dregs --version
+        run: cargo binstall --git https://github.com/EspressoSystems/dregs dregs --no-confirm
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -156,14 +148,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: taiki-e/install-action@cargo-binstall
+
       - name: Install dregs
-        run: |
-          curl -fSL https://api.github.com/repos/EspressoSystems/dregs/releases \
-            | jq -r '[.[] | .assets[] | select(.name == "dregs-x86_64-unknown-linux-musl.tar.gz")][0].url' \
-            | xargs curl -fL -H "Accept: application/octet-stream" -o dregs.tar.gz
-          tar xzf dregs.tar.gz
-          sudo mv dregs /usr/local/bin/dregs
-          dregs --version
+        run: cargo binstall --git https://github.com/EspressoSystems/dregs dregs --no-confirm
 
       - name: Download mutants
         uses: actions/download-artifact@v8

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -131,7 +131,10 @@ jobs:
         run: yarn
 
       - name: Build
-        run: yarn build:all
+        run: yarn build && (FOUNDRY_PROFILE=yul forge build --skip '*.sol' || true)
+
+      - name: Verify yul artifact
+        run: test -f out/yul/Reader4844.yul/Reader4844.json
 
       - name: Download mutants
         uses: actions/download-artifact@v8

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Install packages
         run: yarn
 
+      - name: Build
+        run: yarn build:all
+
       - name: Download mutants
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -30,9 +30,14 @@ jobs:
           fetch-depth: 0
           filter: blob:none
 
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: dregs
+      - name: Install dregs
+        run: |
+          curl -fSL https://api.github.com/repos/EspressoSystems/dregs/releases \
+            | jq -r '[.[] | .assets[] | select(.name == "dregs-x86_64-unknown-linux-musl.tar.gz")][0].url' \
+            | xargs curl -fL -H "Accept: application/octet-stream" -o dregs.tar.gz
+          tar xzf dregs.tar.gz
+          sudo mv dregs /usr/local/bin/dregs
+          dregs --version
 
       - uses: EspressoSystems/dregs/.github/actions/install-solc@main
         with:
@@ -98,9 +103,14 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: dregs
+      - name: Install dregs
+        run: |
+          curl -fSL https://api.github.com/repos/EspressoSystems/dregs/releases \
+            | jq -r '[.[] | .assets[] | select(.name == "dregs-x86_64-unknown-linux-musl.tar.gz")][0].url' \
+            | xargs curl -fL -H "Accept: application/octet-stream" -o dregs.tar.gz
+          tar xzf dregs.tar.gz
+          sudo mv dregs /usr/local/bin/dregs
+          dregs --version
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -146,9 +156,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: dregs
+      - name: Install dregs
+        run: |
+          curl -fSL https://api.github.com/repos/EspressoSystems/dregs/releases \
+            | jq -r '[.[] | .assets[] | select(.name == "dregs-x86_64-unknown-linux-musl.tar.gz")][0].url' \
+            | xargs curl -fL -H "Accept: application/octet-stream" -o dregs.tar.gz
+          tar xzf dregs.tar.gz
+          sudo mv dregs /usr/local/bin/dregs
+          dregs --version
 
       - name: Download mutants
         uses: actions/download-artifact@v8

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ out/
 .DS_Store
 lcov.info
 output_directory
+gambit_out/

--- a/dregs.toml
+++ b/dregs.toml
@@ -1,0 +1,15 @@
+[[target]]
+files = ["src/bridge/SequencerInbox.sol"]
+functions = ["addSequencerL2BatchFromOrigin"]
+
+# Foundry tests
+[[target.test_commands]]
+kind = "foundry"
+args = ["--match-test", "testAddSequencerL2BatchFromOrigin|testFuzz_addSequencerBatch_FeeToken", "--gas-limit", "10000000000"]
+
+# Hardhat contract tests
+[[target.test_commands]]
+kind = "custom"
+command = ["npx", "hardhat", "test", "--network", "hardhat", "test/contract/sequencerInboxForceInclude.spec.ts"]
+symlinks = ["node_modules"]
+

--- a/dregs.toml
+++ b/dregs.toml
@@ -5,7 +5,7 @@ functions = ["addSequencerL2BatchFromOrigin"]
 # Foundry tests
 [[target.test_commands]]
 kind = "foundry"
-args = ["--match-test", "testAddSequencerL2BatchFromOrigin|testFuzz_addSequencerBatch_FeeToken", "--gas-limit", "10000000000"]
+args = ["--match-test", "testAddSequencerL2BatchFromOrigin", "--no-match-test", "testFuzz_", "--gas-limit", "10000000000"]
 
 # Hardhat contract tests
 [[target.test_commands]]

--- a/dregs.toml
+++ b/dregs.toml
@@ -5,7 +5,7 @@ functions = ["addSequencerL2BatchFromOrigin"]
 # Foundry tests
 [[target.test_commands]]
 kind = "foundry"
-args = ["--match-test", "testAddSequencerL2BatchFromOrigin", "--no-match-test", "testFuzz_", "--gas-limit", "10000000000"]
+args = ["--match-test", "testAddSequencerL2BatchFromOrigin", "--no-match-test", "testFuzz_", "--no-match-path", "test/foundry/SequencerInboxTEE.t.sol", "--gas-limit", "10000000000"]
 
 # Hardhat contract tests
 [[target.test_commands]]

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,77 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1773189535,
+        "narHash": "sha256-E1G/Or6MWeP+L6mpQ0iTFLpzSzlpGrITfU2220Gq47g=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6fa2fb4cf4a89ba49fc9dd5a3eb6cde99d388269",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "dregs": {
+      "inputs": {
+        "crane": "crane",
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay",
+        "solc": "solc"
+      },
+      "locked": {
+        "lastModified": 1773757962,
+        "narHash": "sha256-SJvPmD4sEvK1CEH7yxiFpM/2+l9pJQqxHTTSVfhqxtg=",
+        "owner": "EspressoSystems",
+        "repo": "dregs",
+        "rev": "e91315b4dbd543cbc1a50d4877acce33bbe12736",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EspressoSystems",
+        "repo": "dregs",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
       "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
@@ -15,10 +86,28 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "foundry": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1719997877,
@@ -35,7 +124,112 @@
         "type": "github"
       }
     },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1772893680,
+        "narHash": "sha256-JDqZMgxUTCq85ObSaFw0HhE+lvdOre1lx9iI6vYyOEs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "8baab586afc9c9b57645a734c820e4ac0a604af9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "dregs",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1770073757,
+        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1773579282,
+        "narHash": "sha256-LWvZj9Bvm1EuoO6zbX4yjZebwnZNfeTbmCJGS7RGQ3Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5a88de74db0e948139be4b46f9a94d64aa11391c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1682516527,
+        "narHash": "sha256-1joLG1A4mwhMrj4XVp0mBTNIHphVQSEMIlZ50t0Udxk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "171987b2980d986732f0f710cf0e3361989f71c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1666753130,
         "narHash": "sha256-Wff1dGPFSneXJLI2c0kkdWTgxnQ416KE6X4KnFkgPYQ=",
@@ -49,7 +243,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1721303309,
         "narHash": "sha256-/+Yw4tW/mcTRKmkEAO64ObzCQClpSUZpk2flUD9GDHE=",
@@ -65,11 +259,84 @@
         "type": "github"
       }
     },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1682516527,
+        "narHash": "sha256-1joLG1A4mwhMrj4XVp0mBTNIHphVQSEMIlZ50t0Udxk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "171987b2980d986732f0f710cf0e3361989f71c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "dregs": "dregs",
         "foundry": "foundry",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_6",
+        "solc": "solc_2",
         "utils": "utils"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1773630837,
+        "narHash": "sha256-zJhgAGnbVKeBMJOb9ctZm4BGS/Rnrz+5lfSXTVah4HQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f600ea449c7b5bb596fa1cf21c871cc5b9e31316",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "solc": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_4"
+      },
+      "locked": {
+        "lastModified": 1763556226,
+        "narHash": "sha256-AFrrtSaVNraRIgJUAMfvIvX5dH1drETw7zzOVwlwxQo=",
+        "owner": "EspressoSystems",
+        "repo": "nix-solc-bin",
+        "rev": "e3265d0908439bfa7385256d3e16d7ce77a22d35",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EspressoSystems",
+        "repo": "nix-solc-bin",
+        "type": "github"
+      }
+    },
+    "solc_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_7"
+      },
+      "locked": {
+        "lastModified": 1763556226,
+        "narHash": "sha256-AFrrtSaVNraRIgJUAMfvIvX5dH1drETw7zzOVwlwxQo=",
+        "owner": "EspressoSystems",
+        "repo": "nix-solc-bin",
+        "rev": "e3265d0908439bfa7385256d3e16d7ce77a22d35",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EspressoSystems",
+        "repo": "nix-solc-bin",
+        "type": "github"
       }
     },
     "systems": {
@@ -87,9 +354,39 @@
         "type": "github"
       }
     },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1710146030,

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,10 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.utils.url = "github:numtide/flake-utils";
   inputs.foundry.url = "github:shazow/foundry.nix/monthly"; # Use monthly branch for permanent releases
+  inputs.solc.url = "github:EspressoSystems/nix-solc-bin";
+  inputs.dregs.url = "github:EspressoSystems/dregs";
 
-  outputs = { self, nixpkgs, utils, foundry }:
+  outputs = { self, nixpkgs, utils, foundry, solc, dregs }:
     utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs
@@ -11,6 +13,8 @@
             inherit system;
             overlays = [
               foundry.overlay
+              solc.overlays.default
+              dregs.overlays.default
               (final: prev: {
                 # Overlaying nodejs here to ensure nodePackages use the desired
                 # version of nodejs use by the upstream CI.
@@ -27,6 +31,8 @@
             foundry-bin
             nodejs
             yarn
+            solc-bin."0.8.30"
+            pkgs.dregs
           ];
           shellHook = ''
             # Add node executables (incl. hardhat) to PATH


### PR DESCRIPTION
Add dregs mutation testing targeting addSequencerL2BatchFromOrigin in SequencerInbox.sol with both Foundry and Hardhat test runners.

- dregs.toml: configure mutation target and test commands
- mutation-test.yml: sharded CI workflow (3 shards PR, 10 develop)
- flake.nix: add dregs overlay and solc-bin for local dev


https://github.com/EspressoSystems/nitro-contracts/actions/runs/23200703564