### PR TITLE
feat: check for eoa address in tee verifier

### DIFF
--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -19,6 +19,7 @@ import {
     BadSequencerNumber,
     AlreadyValidDASKeyset,
     NoSuchKeyset,
+    NotContract,
     NotForked,
     NotBatchPosterManager,
     NotCodelessOrigin,
@@ -196,6 +197,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     ) external onlyDelegated {
         if (bridge != IBridge(address(0))) revert AlreadyInit();
         if (bridge_ == IBridge(address(0))) revert HadZeroInit();
+        if (_espressoTEEVerifier == address(0) || _espressoTEEVerifier.code.length == 0) revert NotContract(_espressoTEEVerifier);
 
         // Make sure logic contract was created by proper value for 'isUsingFeeToken'.
         // Bridge in ETH based chains doesn't implement nativeToken(). In future it might implement it and return address(0)
@@ -953,6 +955,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     }
 
     function setEspressoTEEVerifier(address _espressoTEEVerifier) external onlyRollupOwner {
+        if (_espressoTEEVerifier == address(0) || _espressoTEEVerifier.code.length == 0) revert NotContract(_espressoTEEVerifier);
         espressoTEEVerifier = IEspressoTEEVerifier(_espressoTEEVerifier);
         emit OwnerFunctionCalled(6);
     }

--- a/test/foundry/SequencerInbox.t.sol
+++ b/test/foundry/SequencerInbox.t.sol
@@ -334,6 +334,40 @@ contract SequencerInboxTest is Test {
         assertEq(address(seqInboxProxy.rollup()), address(_bridge.rollup()), "Invalid rollup");
     }
 
+    function testInitialize_revert_NotContract() public {
+        Bridge _bridge =
+            Bridge(address(new TransparentUpgradeableProxy(address(new Bridge()), proxyAdmin, "")));
+        _bridge.initialize(IOwnable(address(new RollupMock(rollupOwner))));
+
+        address seqInboxLogic =
+            address(new SequencerInbox(MAX_DATA_SIZE, dummyReader4844, false));
+        // -------- Case 1: address(0) --------
+        {
+            SequencerInbox seqInboxProxy = SequencerInbox(TestUtil.deployProxy(seqInboxLogic));
+
+            vm.expectRevert(abi.encodeWithSelector(NotContract.selector, address(0)));
+
+            seqInboxProxy.initialize(
+                IBridge(_bridge),
+                maxTimeVariation,
+                address(0)
+            );
+        }
+
+        // -------- Case 2: EOA --------
+        {
+            SequencerInbox seqInboxProxy = SequencerInbox(TestUtil.deployProxy(seqInboxLogic));
+
+            vm.expectRevert(abi.encodeWithSelector(NotContract.selector, address(0x123456)));
+
+            seqInboxProxy.initialize(
+                IBridge(_bridge),
+                maxTimeVariation,
+                address(0x123456)
+            );
+        }
+    }
+
     function testInitialize_revert_NativeTokenMismatch_EthFeeToken() public {
         Bridge _bridge = Bridge(
             address(new TransparentUpgradeableProxy(address(new Bridge()), proxyAdmin, ""))


### PR DESCRIPTION
[Asana Task](https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1213739697090130?focus=true)

The code was missing a check to see if the `espressoTeeVerifier` address is a valid contract. This means it should not be 0 address and should have code length>0 (so no EOA possible).
Added test `testInitialize_revert_NotContract` for the same as well