### PR TITLE
feat: emit event 7 on setEspressoTEEVerifier

### DIFF
--- a/src/bridge/ISequencerInbox.sol
+++ b/src/bridge/ISequencerInbox.sol
@@ -57,6 +57,9 @@ interface ISequencerInbox is IDelayedMessageProvider {
   ///      To get the full history, search for `OwnerFunctionCalled(5)` events.
   event BatchPosterManagerSet(address newBatchPosterManager);
 
+  /// @dev Owner set the espresso TEE verifier.
+  event EspressoTEEVerifierSet(address newEspressoTEEVerifier);
+
   /// @dev Owner set the buffer config.
   event BufferConfigSet(BufferConfig bufferConfig);
 

--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -1196,6 +1196,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     address _espressoTEEVerifier
   ) external onlyRollupOwner {
     espressoTEEVerifier = IEspressoTEEVerifier(_espressoTEEVerifier);
+    emit EspressoTEEVerifierSet(_espressoTEEVerifier);
     emit OwnerFunctionCalled(7);
   }
 

--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -1196,7 +1196,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     address _espressoTEEVerifier
   ) external onlyRollupOwner {
     espressoTEEVerifier = IEspressoTEEVerifier(_espressoTEEVerifier);
-    emit OwnerFunctionCalled(6);
+    emit OwnerFunctionCalled(7);
   }
 
   function isValidKeysetHash(bytes32 ksHash) external view returns (bool) {


### PR DESCRIPTION
[Asana Task](https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1213757532055495?focus=true)

Both functions `setFeeTokenPricer` and `setEspressoTEEVerifier` are emitting `emit OwnerFunctionCalled(6);` which is a bug and can cause issues for services reading the events

Turns out this bug is not there in `v2.1.3` as the function `setFeeTokenPricer` is not there in that version but it is there in `v3.1.1`
