### PR TITLE
fix: Remove start block from contracts

### DIFF
--- a/scripts/rollupCreation.ts
+++ b/scripts/rollupCreation.ts
@@ -127,8 +127,8 @@ export async function createRollup(
             batchPosterManager: config.batchPosterManager,
             feeTokenPricer: feeTokenPricer,
             customOsp: config.customOsp,
-            espressoTEEVerifier: process.env.ESPRESSO_TEE_VERIFIER || ethers.constants.AddressZero,
-            startHotshotBlock: process.env.START_HOTSHOT_BLOCK ? parseInt(process.env.START_HOTSHOT_BLOCK, 10) : 0,
+            espressoTEEVerifier:
+              process.env.ESPRESSO_TEE_VERIFIER || ethers.constants.AddressZero,
           }
 
     const createRollupTx = await rollupCreator.createRollup(deployParams, {
@@ -359,11 +359,6 @@ async function _getDevRollupConfig(
       ? process.env.ESPRESSO_TEE_VERIFIER
       : ethers.constants.AddressZero
 
-  const startHotshotBlock =
-    process.env.START_HOTSHOT_BLOCK !== undefined
-      ? parseInt(process.env.START_HOTSHOT_BLOCK, 10)
-      : 0
-
   return {
     config: config,
     validators: validators,
@@ -376,7 +371,6 @@ async function _getDevRollupConfig(
     feeTokenPricer: feeTokenPricer,
     customOsp: customOsp,
     espressoTEEVerifier: espressoTEEVerifier,
-    startHotshotBlock: startHotshotBlock,
   }
 
   function _createValidatorAddress(

--- a/src/bridge/ISequencerInbox.sol
+++ b/src/bridge/ISequencerInbox.sol
@@ -76,11 +76,10 @@ interface ISequencerInbox is IDelayedMessageProvider {
     /// @dev Emitted when the Espresso TEE verifier is updated
     event EspressoTEEVerifierSet(address espressoTEEVerifier);
 
-    /// @dev Emitted when the start hotshot block is updated
-    event StartHotshotBlockSet(uint64 startHotshotBlock);
-
     /// @dev Emitted when an Espresso CAS certificate is successfully verified
-    event EspressoCertificateVerified(uint64 startHotshotBlock);
+    event EspressoCertificateVerified(
+        uint256 hotshotBlock, uint256 delayedMessageRead, uint256 messageCount
+    );
 
     function totalDelayedMessagesRead() external view returns (uint256);
 
@@ -367,8 +366,7 @@ interface ISequencerInbox is IDelayedMessageProvider {
         MaxTimeVariation calldata maxTimeVariation_,
         BufferConfig calldata bufferConfig_,
         IFeeTokenPricer feeTokenPricer_,
-        IEspressoTEEVerifier espressoTEEVerifier_,
-        uint64 startHotshotBlock_
+        IEspressoTEEVerifier espressoTEEVerifier_
     ) external;
 
     /// @notice Sets the Espresso TEE verifier contract

--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -152,8 +152,6 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     /// @notice The Espresso TEE verifier used for CAS certificate validation
     IEspressoTEEVerifier public espressoTEEVerifier;
 
-    uint64 public startHotshotBlock;
-
     constructor(
         uint256 _maxDataSize,
         IReader4844 reader4844_,
@@ -194,8 +192,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         ISequencerInbox.MaxTimeVariation calldata maxTimeVariation_,
         BufferConfig memory bufferConfig_,
         IFeeTokenPricer feeTokenPricer_,
-        IEspressoTEEVerifier espressoTEEVerifier_,
-        uint64 startHotshotBlock_
+        IEspressoTEEVerifier espressoTEEVerifier_
     ) external onlyDelegated {
         if (bridge != IBridge(address(0))) revert AlreadyInit();
         if (bridge_ == IBridge(address(0))) revert HadZeroInit();
@@ -226,7 +223,6 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         }
         feeTokenPricer = feeTokenPricer_;
         espressoTEEVerifier = espressoTEEVerifier_;
-        startHotshotBlock = startHotshotBlock_;
     }
 
     /// @notice Allows the rollup owner to sync the rollup address
@@ -384,7 +380,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     ///         [137+]     downstream DA certificate
     ///         The canonical payload signed by CAS is:
     ///         abi.encodePacked(uint64(prevMessageCount), uint64(newMessageCount),
-    ///                          uint64(startHotshotBlock), uint64(afterDelayedMessagesRead),
+    ///                          uint64(hotshotBlock), uint64(afterDelayedMessagesRead),
     ///                          minHotshotBlock, downstreamCert)
     function verifyEspressoCertificate(
         bytes calldata data,
@@ -394,6 +390,9 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     ) internal {
         // Minimum size: Espresso cert fixed (ESPRESSO_CERT_LEN) = 137 bytes
         if (data.length < ESPRESSO_CERT_LEN) revert InvalidCasCertificate();
+
+        // Parse start_hotshot_block from data[48:56]
+        uint64 hotshotBlock = uint64(bytes8(data[48:56]));
 
         // Parse min_hotshot_block from data[64:72]
         uint64 minHotshotBlock = uint64(bytes8(data[64:72]));
@@ -408,7 +407,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         bytes memory payload = abi.encodePacked(
             uint64(prevMessageCount),
             uint64(newMessageCount),
-            startHotshotBlock,
+            hotshotBlock,
             uint64(afterDelayedMessagesRead),
             minHotshotBlock,
             downstreamCert
@@ -424,13 +423,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
             revert InvalidCasCertificate();
         }
 
-        emit EspressoCertificateVerified(startHotshotBlock);
-
-        // Update the startHotshotBlock to ensure that future batches with CAS certs must have a higher min_hotshot_block
-        if (minHotshotBlock > startHotshotBlock) {
-            startHotshotBlock = minHotshotBlock;
-            emit StartHotshotBlockSet(startHotshotBlock);
-        }
+        emit EspressoCertificateVerified(hotshotBlock, afterDelayedMessagesRead, newMessageCount);
     }
 
     /// @inheritdoc ISequencerInbox

--- a/src/rollup/BridgeCreator.sol
+++ b/src/rollup/BridgeCreator.sol
@@ -109,8 +109,7 @@ contract BridgeCreator {
         ISequencerInbox.MaxTimeVariation calldata maxTimeVariation,
         BufferConfig calldata bufferConfig,
         IFeeTokenPricer feeTokenPricer,
-        IEspressoTEEVerifier espressoTEEVerifier,
-        uint64 startHotshotBlock
+        IEspressoTEEVerifier espressoTEEVerifier
     ) external returns (BridgeContracts memory) {
         // use create2 salt to ensure deterministic addresses
         bytes32 create2Salt = keccak256(abi.encode(msg.data, msg.sender));
@@ -136,8 +135,7 @@ contract BridgeCreator {
             maxTimeVariation,
             bufferConfig,
             feeTokenPricer,
-            espressoTEEVerifier,
-            startHotshotBlock
+            espressoTEEVerifier
         );
         frame.inbox.initialize(frame.bridge, frame.sequencerInbox);
         frame.rollupEventInbox.initialize(frame.bridge);

--- a/src/rollup/RollupCreator.sol
+++ b/src/rollup/RollupCreator.sol
@@ -47,7 +47,6 @@ contract RollupCreator is Ownable {
         IFeeTokenPricer feeTokenPricer;
         address customOsp;
         IEspressoTEEVerifier espressoTEEVerifier;
-        uint64 startHotshotBlock;
     }
 
     BridgeCreator public bridgeCreator;
@@ -220,8 +219,7 @@ contract RollupCreator is Ownable {
             deployParams.config.sequencerInboxMaxTimeVariation,
             deployParams.config.bufferConfig,
             deployParams.feeTokenPricer,
-            deployParams.espressoTEEVerifier,
-            deployParams.startHotshotBlock
+            deployParams.espressoTEEVerifier
         );
 
         IEdgeChallengeManager challengeManager = createChallengeManager(

--- a/test/contract/sequencerInbox.spec.4844.ts
+++ b/test/contract/sequencerInbox.spec.4844.ts
@@ -291,7 +291,6 @@ describe('SequencerInbox', async () => {
         },
         constants.AddressZero,
         constants.AddressZero,
-        0
       )
     ).wait()
 

--- a/test/contract/sequencerInboxForceInclude.spec.ts
+++ b/test/contract/sequencerInboxForceInclude.spec.ts
@@ -295,7 +295,6 @@ describe('SequencerInboxForceInclude', async () => {
       },
       constants.AddressZero,
       constants.AddressZero,
-      0
     )
 
     await (

--- a/test/contract/testHelpers.ts
+++ b/test/contract/testHelpers.ts
@@ -358,7 +358,6 @@ export const setupSequencerInbox = async (
     delayConfigDefault,
     constants.AddressZero,
     constants.AddressZero,
-    0
   )
   await (
     await sequencerInbox

--- a/test/e2e/orbitChain.ts
+++ b/test/e2e/orbitChain.ts
@@ -171,9 +171,8 @@ describe('Orbit Chain', () => {
     }
 
     // wait for deposit to be processed
-    const depositRec = await L1TransactionReceipt.monkeyPatchEthDepositWait(
-      depositTx
-    ).wait()
+    const depositRec =
+      await L1TransactionReceipt.monkeyPatchEthDepositWait(depositTx).wait()
     const l2Result = await depositRec.waitForL2(l2Provider)
     expect(l2Result.complete).to.be.true
 
@@ -672,30 +671,30 @@ describe('Orbit Chain', () => {
         fee = BigNumber.from(0)
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (
-              await deployHelper.NICK_CREATE2_VALUE()
-            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
+            (await deployHelper.NICK_CREATE2_VALUE()).add(
+              maxFeePerGas.mul(BigNumber.from(21000))
+            )
           )
         )
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (
-              await deployHelper.ERC2470_VALUE()
-            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
+            (await deployHelper.ERC2470_VALUE()).add(
+              maxFeePerGas.mul(BigNumber.from(21000))
+            )
           )
         )
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (
-              await deployHelper.ZOLTU_VALUE()
-            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
+            (await deployHelper.ZOLTU_VALUE()).add(
+              maxFeePerGas.mul(BigNumber.from(21000))
+            )
           )
         )
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (
-              await deployHelper.ERC1820_VALUE()
-            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
+            (await deployHelper.ERC1820_VALUE()).add(
+              maxFeePerGas.mul(BigNumber.from(21000))
+            )
           )
         )
       } else {
@@ -767,30 +766,30 @@ describe('Orbit Chain', () => {
         fee = BigNumber.from(0)
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (
-              await deployHelper.NICK_CREATE2_VALUE()
-            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
+            (await deployHelper.NICK_CREATE2_VALUE()).add(
+              maxFeePerGas.mul(BigNumber.from(21000))
+            )
           )
         )
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (
-              await deployHelper.ERC2470_VALUE()
-            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
+            (await deployHelper.ERC2470_VALUE()).add(
+              maxFeePerGas.mul(BigNumber.from(21000))
+            )
           )
         )
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (
-              await deployHelper.ZOLTU_VALUE()
-            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
+            (await deployHelper.ZOLTU_VALUE()).add(
+              maxFeePerGas.mul(BigNumber.from(21000))
+            )
           )
         )
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (
-              await deployHelper.ERC1820_VALUE()
-            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
+            (await deployHelper.ERC1820_VALUE()).add(
+              maxFeePerGas.mul(BigNumber.from(21000))
+            )
           )
         )
       } else {
@@ -883,7 +882,6 @@ describe('Orbit Chain', () => {
       feeTokenPricer: ethers.constants.AddressZero,
       customOsp: ethers.constants.AddressZero,
       espressoTEEVerifier: ethers.constants.AddressZero,
-      startHotshotBlock: 0,
     }
 
     /// deploy it

--- a/test/e2e/orbitChain.ts
+++ b/test/e2e/orbitChain.ts
@@ -171,8 +171,9 @@ describe('Orbit Chain', () => {
     }
 
     // wait for deposit to be processed
-    const depositRec =
-      await L1TransactionReceipt.monkeyPatchEthDepositWait(depositTx).wait()
+    const depositRec = await L1TransactionReceipt.monkeyPatchEthDepositWait(
+      depositTx
+    ).wait()
     const l2Result = await depositRec.waitForL2(l2Provider)
     expect(l2Result.complete).to.be.true
 
@@ -671,30 +672,30 @@ describe('Orbit Chain', () => {
         fee = BigNumber.from(0)
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (await deployHelper.NICK_CREATE2_VALUE()).add(
-              maxFeePerGas.mul(BigNumber.from(21000))
-            )
+            (
+              await deployHelper.NICK_CREATE2_VALUE()
+            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
           )
         )
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (await deployHelper.ERC2470_VALUE()).add(
-              maxFeePerGas.mul(BigNumber.from(21000))
-            )
+            (
+              await deployHelper.ERC2470_VALUE()
+            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
           )
         )
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (await deployHelper.ZOLTU_VALUE()).add(
-              maxFeePerGas.mul(BigNumber.from(21000))
-            )
+            (
+              await deployHelper.ZOLTU_VALUE()
+            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
           )
         )
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (await deployHelper.ERC1820_VALUE()).add(
-              maxFeePerGas.mul(BigNumber.from(21000))
-            )
+            (
+              await deployHelper.ERC1820_VALUE()
+            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
           )
         )
       } else {
@@ -766,30 +767,30 @@ describe('Orbit Chain', () => {
         fee = BigNumber.from(0)
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (await deployHelper.NICK_CREATE2_VALUE()).add(
-              maxFeePerGas.mul(BigNumber.from(21000))
-            )
+            (
+              await deployHelper.NICK_CREATE2_VALUE()
+            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
           )
         )
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (await deployHelper.ERC2470_VALUE()).add(
-              maxFeePerGas.mul(BigNumber.from(21000))
-            )
+            (
+              await deployHelper.ERC2470_VALUE()
+            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
           )
         )
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (await deployHelper.ZOLTU_VALUE()).add(
-              maxFeePerGas.mul(BigNumber.from(21000))
-            )
+            (
+              await deployHelper.ZOLTU_VALUE()
+            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
           )
         )
         fee = fee.add(
           await _scaleFrom18ToNative(
-            (await deployHelper.ERC1820_VALUE()).add(
-              maxFeePerGas.mul(BigNumber.from(21000))
-            )
+            (
+              await deployHelper.ERC1820_VALUE()
+            ).add(maxFeePerGas.mul(BigNumber.from(21000)))
           )
         )
       } else {

--- a/test/foundry/BridgeCreator.t.sol
+++ b/test/foundry/BridgeCreator.t.sol
@@ -109,8 +109,7 @@ contract BridgeCreatorTest is Test {
             timeVars,
             bufferConfig,
             IFeeTokenPricer(address(0)),
-            IEspressoTEEVerifier(address(0)),
-            0
+            IEspressoTEEVerifier(address(0))
         );
         (
             IBridge bridge,
@@ -180,8 +179,7 @@ contract BridgeCreatorTest is Test {
             timeVars,
             bufferConfig,
             IFeeTokenPricer(feeTokenPricer),
-            IEspressoTEEVerifier(address(0)),
-            0
+            IEspressoTEEVerifier(address(0))
         );
         (IBridge bridge, IInboxBase inbox, IRollupEventInbox eventInbox, IOutbox outbox) =
             (contracts.bridge, contracts.inbox, contracts.rollupEventInbox, contracts.outbox);
@@ -249,8 +247,7 @@ contract BridgeCreatorTest is Test {
             timeVars,
             bufferConfig,
             IFeeTokenPricer(address(0)),
-            IEspressoTEEVerifier(address(0)),
-            0
+            IEspressoTEEVerifier(address(0))
         );
 
         // can only deploy once from the same address and config
@@ -262,8 +259,7 @@ contract BridgeCreatorTest is Test {
             timeVars,
             bufferConfig,
             IFeeTokenPricer(address(0)),
-            IEspressoTEEVerifier(address(0)),
-            0
+            IEspressoTEEVerifier(address(0))
         );
 
         // can deploy from a different address
@@ -275,8 +271,7 @@ contract BridgeCreatorTest is Test {
             timeVars,
             bufferConfig,
             IFeeTokenPricer(address(0)),
-            IEspressoTEEVerifier(address(0)),
-            0
+            IEspressoTEEVerifier(address(0))
         );
     }
 }

--- a/test/foundry/ERC20RollupEventInbox.t.sol
+++ b/test/foundry/ERC20RollupEventInbox.t.sol
@@ -237,8 +237,7 @@ contract ERC20RollupEventInboxTest is AbsRollupEventInboxTest {
             }),
             bufferConfig,
             IFeeTokenPricer(makeAddr("feeTokenPricer")),
-            IEspressoTEEVerifier(address(0)),
-            0
+            IEspressoTEEVerifier(address(0))
         );
 
         vm.prank(rollup);

--- a/test/foundry/Rollup.t.sol
+++ b/test/foundry/Rollup.t.sol
@@ -206,8 +206,7 @@ contract RollupTest is Test {
             batchPosterManager: address(0),
             feeTokenPricer: IFeeTokenPricer(address(0)),
             customOsp: address(0),
-            espressoTEEVerifier: IEspressoTEEVerifier(address(0)),
-            startHotshotBlock: 0
+            espressoTEEVerifier: IEspressoTEEVerifier(address(0))
         });
 
         address rollupAddr = rollupCreator.createRollup(param);

--- a/test/foundry/RollupCreator.t.sol
+++ b/test/foundry/RollupCreator.t.sol
@@ -170,8 +170,7 @@ contract RollupCreatorTest is Test {
             batchPosterManager: batchPosterManager,
             feeTokenPricer: IFeeTokenPricer(address(0)),
             customOsp: customOsp,
-            espressoTEEVerifier: IEspressoTEEVerifier(address(0)),
-            startHotshotBlock: 0
+            espressoTEEVerifier: IEspressoTEEVerifier(address(0))
         });
         address rollupAddress =
             rollupCreator.createRollup{value: factoryDeploymentFunds}(deployParams);
@@ -334,8 +333,7 @@ contract RollupCreatorTest is Test {
             batchPosterManager: batchPosterManager,
             feeTokenPricer: feeTokenPricer,
             customOsp: customOsp,
-            espressoTEEVerifier: IEspressoTEEVerifier(address(0)),
-            startHotshotBlock: 0
+            espressoTEEVerifier: IEspressoTEEVerifier(address(0))
         });
 
         vm.mockCall(
@@ -505,8 +503,7 @@ contract RollupCreatorTest is Test {
             batchPosterManager: batchPosterManager,
             feeTokenPricer: IFeeTokenPricer(address(0)),
             customOsp: address(0),
-            espressoTEEVerifier: IEspressoTEEVerifier(address(0)),
-            startHotshotBlock: 0
+            espressoTEEVerifier: IEspressoTEEVerifier(address(0))
         });
         address rollupAddress =
             rollupCreator.createRollup{value: factoryDeploymentFunds}(deployParams);

--- a/test/foundry/SequencerInbox.t.sol
+++ b/test/foundry/SequencerInbox.t.sol
@@ -92,8 +92,7 @@ contract SequencerInboxTest is Test {
             maxTimeVariation,
             bufferConfig,
             IFeeTokenPricer(address(0)),
-            IEspressoTEEVerifier(address(0)),
-            0
+            IEspressoTEEVerifier(address(0))
         );
 
         vm.prank(rollupOwner);
@@ -133,8 +132,7 @@ contract SequencerInboxTest is Test {
             maxTimeVariation,
             bufferConfigDefault,
             IFeeTokenPricer(makeAddr("feeTokenPricer")),
-            IEspressoTEEVerifier(address(0)),
-            0
+            IEspressoTEEVerifier(address(0))
         );
 
         vm.prank(rollupOwner);
@@ -317,8 +315,7 @@ contract SequencerInboxTest is Test {
             maxTimeVariation,
             bufferConfig,
             IFeeTokenPricer(address(0)),
-            IEspressoTEEVerifier(address(0)),
-            0
+            IEspressoTEEVerifier(address(0))
         );
 
         assertEq(seqInboxProxy.isUsingFeeToken(), false, "Invalid isUsingFeeToken");
@@ -345,8 +342,7 @@ contract SequencerInboxTest is Test {
             maxTimeVariation,
             bufferConfig,
             feeTokenPricer,
-            IEspressoTEEVerifier(address(0)),
-            0
+            IEspressoTEEVerifier(address(0))
         );
 
         assertEq(seqInboxProxy.isUsingFeeToken(), true, "Invalid isUsingFeeToken");
@@ -376,8 +372,7 @@ contract SequencerInboxTest is Test {
             maxTimeVariation,
             bufferConfig,
             IFeeTokenPricer(address(0)),
-            IEspressoTEEVerifier(address(0)),
-            0
+            IEspressoTEEVerifier(address(0))
         );
     }
 
@@ -400,8 +395,7 @@ contract SequencerInboxTest is Test {
             maxTimeVariation,
             bufferConfig,
             IFeeTokenPricer(makeAddr("feeTokenPricer")),
-            IEspressoTEEVerifier(address(0)),
-            0
+            IEspressoTEEVerifier(address(0))
         );
     }
 
@@ -417,8 +411,7 @@ contract SequencerInboxTest is Test {
             maxTimeVariation,
             bufferConfigDefault,
             pricer,
-            IEspressoTEEVerifier(address(0)),
-            0
+            IEspressoTEEVerifier(address(0))
         );
     }
 

--- a/test/foundry/SequencerInboxEspresso.t.sol
+++ b/test/foundry/SequencerInboxEspresso.t.sol
@@ -34,8 +34,7 @@ contract SequencerInboxEspressoTest is Test {
         IBridge.BatchDataLocation dataLocation
     );
     event SequencerBatchData(uint256 indexed batchSequenceNumber, bytes data);
-    event StartHotshotBlockSet(uint64 startHotshotBlock);
-    event EspressoCertificateVerified(uint64 startHotshotBlock);
+    event EspressoCertificateVerified(uint256 hotshotBlock, uint256 delayedMessageRead, uint256 messageCount);
     event EspressoTEEVerifierSet(address espressoTEEVerifier);
 
     // ── Constants ─────────────────────────────────────────────────────
@@ -103,7 +102,7 @@ contract SequencerInboxEspressoTest is Test {
 
     /// @dev Build the full certificate data that SequencerInbox expects.
     ///      Layout: [0..31] CAS header | [32..39] startMessagePos |
-    ///              [40..47] endMessagePos | [48..55] startHotshotBlock |
+    ///              [40..47] endMessagePos | [48..55] hotshotBlock |
     ///              [56..63] afterDelayedMessagesRead | [64..71] minHotshotBlock |
     ///              [72..136] signature | [137+] downstreamCert
     function _buildCertData(
@@ -152,9 +151,7 @@ contract SequencerInboxEspressoTest is Test {
     }
 
     /// @dev Deploy Bridge + SequencerInbox with espresso TEE verifier enabled.
-    function _deployEspressoRollup(
-        uint64 startBlock
-    ) internal returns (SequencerInbox seqInbox, Bridge bridge) {
+    function _deployEspressoRollup() internal returns (SequencerInbox seqInbox, Bridge bridge) {
         EspressoRollupMock rollupMock = new EspressoRollupMock(rollupOwner);
 
         Bridge bridgeImpl = new Bridge();
@@ -175,8 +172,7 @@ contract SequencerInboxEspressoTest is Test {
             maxTimeVariation,
             bufferConfigDefault,
             IFeeTokenPricer(address(0)),
-            IEspressoTEEVerifier(address(teeVerifierMock)),
-            startBlock
+            IEspressoTEEVerifier(address(teeVerifierMock))
         );
 
         vm.prank(rollupOwner);
@@ -199,6 +195,7 @@ contract SequencerInboxEspressoTest is Test {
     function _prepareValidBatch(
         SequencerInbox seqInbox,
         Bridge bridge,
+        uint64 hotshotBlock,
         uint64 minHotshotBlock,
         bytes memory downstreamCert
     )
@@ -220,7 +217,7 @@ contract SequencerInboxEspressoTest is Test {
         bytes32 userDataHash = _computeUserDataHash(
             prevMsgCount,
             newMsgCount,
-            seqInbox.startHotshotBlock(),
+            hotshotBlock,
             delayedMessagesRead,
             minHotshotBlock,
             downstreamCert
@@ -230,7 +227,7 @@ contract SequencerInboxEspressoTest is Test {
         data = _buildCertData(
             uint64(prevMsgCount),
             uint64(newMsgCount),
-            seqInbox.startHotshotBlock(),
+            hotshotBlock,
             uint64(delayedMessagesRead),
             minHotshotBlock,
             sig,
@@ -248,13 +245,13 @@ contract SequencerInboxEspressoTest is Test {
     }
 
     function testAddBatchWithValidEspressoCert() public {
-        (SequencerInbox seqInbox, Bridge bridge) = _deployEspressoRollup(1);
+        (SequencerInbox seqInbox, Bridge bridge) = _deployEspressoRollup();
         _enqueueDelayed(bridge);
         vm.fee(60 gwei);
 
         bytes memory downstream = hex"00deadbeef";
         (bytes memory data, uint256 seqNum, uint256 delayedRead, uint256 prevMsg, uint256 newMsg) =
-            _prepareValidBatch(seqInbox, bridge, 1, downstream);
+            _prepareValidBatch(seqInbox, bridge, 0, 1, downstream);
 
         uint256 countBefore = bridge.sequencerMessageCount();
 
@@ -267,13 +264,13 @@ contract SequencerInboxEspressoTest is Test {
     }
 
     function testAddBatchFromOriginWithValidEspressoCert() public {
-        (SequencerInbox seqInbox, Bridge bridge) = _deployEspressoRollup(0);
+        (SequencerInbox seqInbox, Bridge bridge) = _deployEspressoRollup();
         _enqueueDelayed(bridge);
         vm.fee(60 gwei);
 
         bytes memory downstream = hex"00deadbeef";
         (bytes memory data, uint256 seqNum, uint256 delayedRead, uint256 prevMsg, uint256 newMsg) =
-            _prepareValidBatch(seqInbox, bridge, 1, downstream);
+            _prepareValidBatch(seqInbox, bridge, 0, 1, downstream);
 
         uint256 countBefore = bridge.sequencerMessageCount();
 
@@ -286,7 +283,7 @@ contract SequencerInboxEspressoTest is Test {
     }
 
     function testRevertUnregisteredSigner() public {
-        (SequencerInbox seqInbox, Bridge bridge) = _deployEspressoRollup(0);
+        (SequencerInbox seqInbox, Bridge bridge) = _deployEspressoRollup();
         _enqueueDelayed(bridge);
         vm.fee(60 gwei);
 
@@ -298,7 +295,7 @@ contract SequencerInboxEspressoTest is Test {
         bytes memory downstream = hex"deadbeef";
 
         bytes32 userDataHash = _computeUserDataHash(
-            prevMsg, newMsg, seqInbox.startHotshotBlock(), delayedRead, 1, downstream
+            prevMsg, newMsg, 0, delayedRead, 1, downstream
         );
 
         // Sign with unregistered key
@@ -306,7 +303,7 @@ contract SequencerInboxEspressoTest is Test {
         bytes memory data = _buildCertData(
             uint64(prevMsg),
             uint64(newMsg),
-            seqInbox.startHotshotBlock(),
+            0,
             uint64(delayedRead),
             1,
             sig,
@@ -321,7 +318,7 @@ contract SequencerInboxEspressoTest is Test {
     }
 
     function testRevertCertTooShort() public {
-        (SequencerInbox seqInbox, Bridge bridge) = _deployEspressoRollup(0);
+        (SequencerInbox seqInbox, Bridge bridge) = _deployEspressoRollup();
         _enqueueDelayed(bridge);
         vm.fee(60 gwei);
 
@@ -341,37 +338,34 @@ contract SequencerInboxEspressoTest is Test {
         );
     }
 
-    function testStartHotshotBlockUpdated() public {
-        uint64 initialBlock = 5;
-        uint64 newMinBlock = 10;
+    function testEspressoCertificateVerifiedEvent() public {
+        uint64 hotshotBlock = 5;
 
-        (SequencerInbox seqInbox, Bridge bridge) = _deployEspressoRollup(initialBlock);
+        (SequencerInbox seqInbox, Bridge bridge) = _deployEspressoRollup();
         _enqueueDelayed(bridge);
         vm.fee(60 gwei);
 
         bytes memory downstream = hex"00cafe";
         (bytes memory data, uint256 seqNum, uint256 delayedRead, uint256 prevMsg, uint256 newMsg) =
-            _prepareValidBatch(seqInbox, bridge, newMinBlock, downstream);
+            _prepareValidBatch(seqInbox, bridge, hotshotBlock, 10, downstream);
 
         vm.expectEmit(false, false, false, true, address(seqInbox));
-        emit StartHotshotBlockSet(newMinBlock);
+        emit EspressoCertificateVerified(hotshotBlock, delayedRead, newMsg);
 
         vm.prank(tx.origin);
         seqInbox.addSequencerL2Batch(
             seqNum, data, delayedRead, IGasRefunder(address(0)), prevMsg, newMsg
         );
-
-        assertEq(seqInbox.startHotshotBlock(), newMinBlock, "startHotshotBlock not updated");
     }
 
     function testCertStrippedFromBatchDataEvent() public {
-        (SequencerInbox seqInbox, Bridge bridge) = _deployEspressoRollup(0);
+        (SequencerInbox seqInbox, Bridge bridge) = _deployEspressoRollup();
         _enqueueDelayed(bridge);
         vm.fee(60 gwei);
 
         bytes memory downstream = hex"00aabbccdd";
         (bytes memory data, uint256 seqNum, uint256 delayedRead, uint256 prevMsg, uint256 newMsg) =
-            _prepareValidBatch(seqInbox, bridge, 1, downstream);
+            _prepareValidBatch(seqInbox, bridge, 0, 1, downstream);
 
         // Expect SequencerBatchData to contain only the downstream cert (data[137:])
         vm.expectEmit(true, false, false, true, address(seqInbox));
@@ -384,7 +378,7 @@ contract SequencerInboxEspressoTest is Test {
     }
 
     function testSetEspressoTEEVerifier_OnlyOwner() public {
-        (SequencerInbox seqInbox,) = _deployEspressoRollup(0);
+        (SequencerInbox seqInbox,) = _deployEspressoRollup();
 
         address newVerifier = address(0xBEEF);
 
@@ -398,61 +392,5 @@ contract SequencerInboxEspressoTest is Test {
         vm.expectRevert(abi.encodeWithSelector(NotOwner.selector, nonOwner, rollupOwner));
         vm.prank(nonOwner);
         seqInbox.setEspressoTEEVerifier(IEspressoTEEVerifier(address(0)));
-    }
-
-    function testSecondBatchUsesUpdatedStartHotshotBlock() public {
-        uint64 initialBlock = 5;
-        uint64 firstMinBlock = 10;
-        uint64 secondMinBlock = 15;
-
-        (SequencerInbox seqInbox, Bridge bridge) = _deployEspressoRollup(initialBlock);
-        _enqueueDelayed(bridge);
-        _enqueueDelayed(bridge); // enqueue a second delayed msg for the second batch
-        vm.fee(60 gwei);
-
-        // ── First batch: updates startHotshotBlock from 5 → 10 ──
-        {
-            bytes memory downstream1 = hex"00cafe";
-            (
-                bytes memory data1,
-                uint256 seqNum1,
-                uint256 delayedRead1,
-                uint256 prevMsg1,
-                uint256 newMsg1
-            ) = _prepareValidBatch(seqInbox, bridge, firstMinBlock, downstream1);
-
-            assertEq(seqInbox.startHotshotBlock(), initialBlock, "initial block mismatch");
-
-            vm.prank(tx.origin);
-            seqInbox.addSequencerL2Batch(
-                seqNum1, data1, delayedRead1, IGasRefunder(address(0)), prevMsg1, newMsg1
-            );
-        }
-
-        assertEq(seqInbox.startHotshotBlock(), firstMinBlock, "block not updated after first batch");
-
-        // ── Second batch: must be signed with startHotshotBlock=10 (the updated value) ──
-        {
-            bytes memory downstream2 = hex"00beef";
-            (
-                bytes memory data2,
-                uint256 seqNum2,
-                uint256 delayedRead2,
-                uint256 prevMsg2,
-                uint256 newMsg2
-            ) = _prepareValidBatch(seqInbox, bridge, secondMinBlock, downstream2);
-
-            vm.expectEmit(false, false, false, true, address(seqInbox));
-            emit StartHotshotBlockSet(secondMinBlock);
-
-            vm.prank(tx.origin);
-            seqInbox.addSequencerL2Batch(
-                seqNum2, data2, delayedRead2, IGasRefunder(address(0)), prevMsg2, newMsg2
-            );
-        }
-
-        assertEq(
-            seqInbox.startHotshotBlock(), secondMinBlock, "block not updated after second batch"
-        );
     }
 }


### PR DESCRIPTION
# Description
This PR removes the startHotshotBlock from the contract because CAS only reads the event and never the contract state
It also modifies the event to match what is expected in CAS code

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214916434942620